### PR TITLE
Fix ROI mosaic throughput bottleneck and 503 handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "opencv-python>=4.5.5.62",
     "qdarkstyle>=3.0.3",
     "beholder-client>=0.3.1",
+    "httpx>=0.27.0",
     "sharktopoda-client>=0.4.5",
     "platformdirs>=4.0.0",
     "iso8601>=2.1.0",

--- a/src/vars_gridview/services/roi_service.py
+++ b/src/vars_gridview/services/roi_service.py
@@ -14,6 +14,7 @@ import logging
 import time
 
 import cv2
+import httpx
 import numpy as np
 import requests
 from beholder_client import BeholderClient
@@ -23,12 +24,13 @@ from vars_gridview.lib.m3.clients import SkimmerClient
 
 _log = logging.getLogger(__name__)
 
-# Skimmer returns 503 + Retry-After when its crop pool is shedding load
-# rather than queuing indefinitely; a couple of short retries lets a tile
-# recover instead of going permanently blank for what's usually a brief dip.
-_CROP_BUSY_MAX_RETRIES = 2
-_CROP_BUSY_DEFAULT_RETRY_SECONDS = 1.0
-_CROP_BUSY_MAX_RETRY_SECONDS = 5.0
+# Skimmer and Beholder both return 503 + Retry-After when their respective
+# work pools are shedding load rather than queuing indefinitely; a couple of
+# short retries lets a tile recover instead of going permanently blank for
+# what's usually a brief dip.
+_BUSY_MAX_RETRIES = 2
+_BUSY_DEFAULT_RETRY_SECONDS = 1.0
+_BUSY_MAX_RETRY_SECONDS = 5.0
 
 
 class RoiService:
@@ -71,7 +73,7 @@ class RoiService:
         x, y, xf, yf = assoc.box
         try:
             if elapsed_time_millis is not None:
-                raw_bytes: bytes = self._beholder.capture_raw(
+                raw_bytes = self._capture_raw_with_busy_retry(
                     image_url, elapsed_time_millis
                 )
                 full_image = cv2.imdecode(
@@ -86,7 +88,7 @@ class RoiService:
                 response.raise_for_status()
                 arr = np.frombuffer(response.content, np.uint8)
                 return cv2.imdecode(arr, cv2.IMREAD_COLOR)
-        except requests.HTTPError as exc:
+        except (requests.HTTPError, httpx.HTTPStatusError) as exc:
             _log.error(f"HTTP error fetching ROI for {assoc.uuid}: {exc}")
             return None
         except Exception as exc:  # noqa: BLE001
@@ -103,10 +105,10 @@ class RoiService:
         the caller's own handling -- only 503 is retried here.
         """
         response = self._skimmer.crop(url, left, top, right, bottom)
-        for _ in range(_CROP_BUSY_MAX_RETRIES):
+        for _ in range(_BUSY_MAX_RETRIES):
             if response.status_code != 503:
                 return response
-            wait_seconds = self._retry_after_seconds(response)
+            wait_seconds = self._retry_after_seconds(response.headers)
             _log.warning(
                 f"Skimmer busy (503) for {url}; retrying in {wait_seconds:.1f}s"
             )
@@ -114,16 +116,37 @@ class RoiService:
             response = self._skimmer.crop(url, left, top, right, bottom)
         return response
 
+    def _capture_raw_with_busy_retry(self, url: str, elapsed_time_millis: int) -> bytes:
+        """Call :meth:`BeholderClient.capture_raw`, retrying a 503 (capture pool busy).
+
+        ``beholder_client`` raises ``httpx.HTTPStatusError`` (with the
+        response, including headers, attached) rather than returning an
+        error response like :class:`SkimmerClient.crop` does. Only 503 is
+        retried here; any other status or error propagates immediately.
+        """
+        for _ in range(_BUSY_MAX_RETRIES):
+            try:
+                return self._beholder.capture_raw(url, elapsed_time_millis)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code != 503:
+                    raise
+                wait_seconds = self._retry_after_seconds(exc.response.headers)
+                _log.warning(
+                    f"Beholder busy (503) for {url}; retrying in {wait_seconds:.1f}s"
+                )
+                time.sleep(wait_seconds)
+        return self._beholder.capture_raw(url, elapsed_time_millis)
+
     @staticmethod
-    def _retry_after_seconds(response: requests.Response) -> float:
-        header = response.headers.get("Retry-After")
+    def _retry_after_seconds(headers) -> float:
+        header = headers.get("Retry-After")
         if header is None:
-            return _CROP_BUSY_DEFAULT_RETRY_SECONDS
+            return _BUSY_DEFAULT_RETRY_SECONDS
         try:
             seconds = float(header)
         except ValueError:
-            return _CROP_BUSY_DEFAULT_RETRY_SECONDS
-        return max(0.0, min(seconds, _CROP_BUSY_MAX_RETRY_SECONDS))
+            return _BUSY_DEFAULT_RETRY_SECONDS
+        return max(0.0, min(seconds, _BUSY_MAX_RETRY_SECONDS))
 
     def fetch_full_image(
         self,

--- a/src/vars_gridview/services/roi_service.py
+++ b/src/vars_gridview/services/roi_service.py
@@ -11,6 +11,7 @@ responsive.
 from __future__ import annotations
 
 import logging
+import time
 
 import cv2
 import numpy as np
@@ -21,6 +22,13 @@ from vars_gridview.lib.annotation.association import BoundingBoxAssociation
 from vars_gridview.lib.m3.clients import SkimmerClient
 
 _log = logging.getLogger(__name__)
+
+# Skimmer returns 503 + Retry-After when its crop pool is shedding load
+# rather than queuing indefinitely; a couple of short retries lets a tile
+# recover instead of going permanently blank for what's usually a brief dip.
+_CROP_BUSY_MAX_RETRIES = 2
+_CROP_BUSY_DEFAULT_RETRY_SECONDS = 1.0
+_CROP_BUSY_MAX_RETRY_SECONDS = 5.0
 
 
 class RoiService:
@@ -74,7 +82,7 @@ class RoiService:
                     return None
                 return full_image[y:yf, x:xf]
             else:
-                response = self._skimmer.crop(image_url, x, y, xf, yf)
+                response = self._crop_with_busy_retry(image_url, x, y, xf, yf)
                 response.raise_for_status()
                 arr = np.frombuffer(response.content, np.uint8)
                 return cv2.imdecode(arr, cv2.IMREAD_COLOR)
@@ -84,6 +92,38 @@ class RoiService:
         except Exception as exc:  # noqa: BLE001
             _log.error(f"Unexpected error fetching ROI for {assoc.uuid}: {exc}")
             return None
+
+    def _crop_with_busy_retry(
+        self, url: str, left: int, top: int, right: int, bottom: int
+    ) -> requests.Response:
+        """Call :meth:`SkimmerClient.crop`, retrying a 503 (crop pool busy).
+
+        Honors the response's ``Retry-After`` header, capped to a sane
+        range. Any other status or error is returned/raised immediately for
+        the caller's own handling -- only 503 is retried here.
+        """
+        response = self._skimmer.crop(url, left, top, right, bottom)
+        for _ in range(_CROP_BUSY_MAX_RETRIES):
+            if response.status_code != 503:
+                return response
+            wait_seconds = self._retry_after_seconds(response)
+            _log.warning(
+                f"Skimmer busy (503) for {url}; retrying in {wait_seconds:.1f}s"
+            )
+            time.sleep(wait_seconds)
+            response = self._skimmer.crop(url, left, top, right, bottom)
+        return response
+
+    @staticmethod
+    def _retry_after_seconds(response: requests.Response) -> float:
+        header = response.headers.get("Retry-After")
+        if header is None:
+            return _CROP_BUSY_DEFAULT_RETRY_SECONDS
+        try:
+            seconds = float(header)
+        except ValueError:
+            return _CROP_BUSY_DEFAULT_RETRY_SECONDS
+        return max(0.0, min(seconds, _CROP_BUSY_MAX_RETRY_SECONDS))
 
     def fetch_full_image(
         self,

--- a/src/vars_gridview/ui/coordinators/mosaic_roi_loading_coordinator.py
+++ b/src/vars_gridview/ui/coordinators/mosaic_roi_loading_coordinator.py
@@ -86,7 +86,11 @@ class MosaicRoiLoadingCoordinator(QtCore.QObject):
             rect_widget.assign_roi_batch_generation(generation)
             rect_widget.roiRefreshed.connect(self._on_rect_roi_refreshed)
             self._inflight += 1
-            rect_widget.request_roi_refresh()
+            # No debounce: the coordinator calls this exactly once per tile,
+            # so there's nothing to coalesce -- unlike interactive callers
+            # (e.g. dragging a box), which legitimately fire repeatedly and
+            # rely on the default debounce to coalesce them.
+            rect_widget.request_roi_refresh(debounce=False)
 
     @QtCore.pyqtSlot(object)
     def _on_rect_roi_refreshed(self, rect_widget: object) -> None:

--- a/src/vars_gridview/ui/mosaic/image_mosaic.py
+++ b/src/vars_gridview/ui/mosaic/image_mosaic.py
@@ -236,9 +236,13 @@ class ImageMosaic(QtCore.QObject):
         self._current_build_stage_key: str | None = None
         self._load_coordinator = MosaicLoadCoordinator(parent=self)
         self._load_coordinator.stage_progress.connect(self._on_load_stage_progress)
+        # Was 4, which combined with the per-tile debounce created a hard
+        # ~20-30 tiles/s ceiling regardless of backend speed. Higher than
+        # ~20 stops helping on typical hardware -- gridview's worker threads
+        # share one process/GIL, so more of them mostly adds contention.
         self._roi_loading = MosaicRoiLoadingCoordinator(
             parent=self,
-            max_concurrency=4,
+            max_concurrency=16,
         )
         self._roi_loading.progress.connect(self._on_roi_loading_progress)
         self._similarity = MosaicSimilarityCoordinator(

--- a/src/vars_gridview/ui/mosaic/rect_widget.py
+++ b/src/vars_gridview/ui/mosaic/rect_widget.py
@@ -311,9 +311,19 @@ class RectWidget(QtWidgets.QGraphicsWidget):
         self.invalidate_embedding_cache()
         self.update()
 
-    def request_roi_refresh(self) -> None:
-        """Refresh ROI image asynchronously and apply only the latest result."""
-        self.request_roi_refresh_debounced()
+    def request_roi_refresh(self, *, debounce: bool = True) -> None:
+        """Refresh ROI image asynchronously and apply only the latest result.
+
+        Args:
+            debounce: If ``True`` (default), coalesce rapid repeated calls
+                (e.g. from interactive box editing) behind a short delay.
+                Bulk loaders that call this once per tile, with nothing to
+                coalesce against, should pass ``False`` to skip it.
+        """
+        if debounce:
+            self.request_roi_refresh_debounced()
+        else:
+            self._start_roi_refresh_worker()
 
     def request_roi_refresh_debounced(self, debounce_ms: int = 120) -> None:
         """Schedule an ROI refresh after a short debounce delay."""

--- a/tests/test_mosaic_roi_loading_coordinator.py
+++ b/tests/test_mosaic_roi_loading_coordinator.py
@@ -28,7 +28,7 @@ class _FakeRectWidget:
     def assign_roi_batch_generation(self, generation) -> None:
         self.roi_batch_generation = generation
 
-    def request_roi_refresh(self) -> None:
+    def request_roi_refresh(self, *, debounce: bool = True) -> None:
         self.roiRefreshed.emit(self)
 
 
@@ -59,9 +59,9 @@ def test_cancel_mid_load_stops_pumping_and_skips_callback() -> None:
 
     original_request = widgets[0].request_roi_refresh
 
-    def cancelling_request() -> None:
+    def cancelling_request(*, debounce: bool = True) -> None:
         cancel_event.set()
-        original_request()
+        original_request(debounce=debounce)
 
     widgets[0].request_roi_refresh = cancelling_request
     on_complete_calls = []

--- a/tests/test_roi_service.py
+++ b/tests/test_roi_service.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+import httpx
 import requests
 
 from vars_gridview.services.roi_service import RoiService
+
+
+def _httpx_status_error(
+    status_code: int, headers: dict | None = None
+) -> httpx.HTTPStatusError:
+    """Build a realistic httpx.HTTPStatusError, as beholder_client raises on non-2xx."""
+    request = httpx.Request("POST", "https://beholder.example/capture")
+    response = httpx.Response(status_code, headers=headers or {}, request=request)
+    return httpx.HTTPStatusError("busy", request=request, response=response)
 
 
 class _FakeAssoc:
@@ -47,12 +57,23 @@ class _FakeSkimmer:
 
 
 class _FakeBeholder:
-    def __init__(self, payload: bytes = b"frame") -> None:
+    def __init__(
+        self, payload: bytes = b"frame", responses: list | None = None
+    ) -> None:
         self.payload = payload
         self.calls = []
+        # If given, one queued item is consumed per call, in order: bytes on
+        # success, or an exception instance to raise (e.g. an
+        # httpx.HTTPStatusError for a 503).
+        self._responses = list(responses) if responses is not None else None
 
     def capture_raw(self, image_url, elapsed_time_millis):
         self.calls.append((image_url, elapsed_time_millis))
+        if self._responses is not None:
+            item = self._responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
         return self.payload
 
 
@@ -254,3 +275,64 @@ def test_fetch_roi_retry_after_header_is_capped(monkeypatch) -> None:
 
     assert sleeps[0] == 5.0  # capped
     assert sleeps[1] == 1.0  # unparsable -> default
+
+
+def test_fetch_roi_retries_beholder_503_then_succeeds(monkeypatch) -> None:
+    sleeps = []
+    monkeypatch.setattr(
+        "vars_gridview.services.roi_service.time.sleep", lambda s: sleeps.append(s)
+    )
+    monkeypatch.setattr(
+        "vars_gridview.services.roi_service.np.frombuffer",
+        lambda *_args, **_kwargs: b"arr",
+    )
+    monkeypatch.setattr(
+        "vars_gridview.services.roi_service.cv2.imdecode",
+        lambda *_args, **_kwargs: _FakeArray(),
+    )
+
+    beholder = _FakeBeholder(
+        responses=[
+            _httpx_status_error(503, headers={"Retry-After": "0.5"}),
+            _httpx_status_error(503, headers={"Retry-After": "0.5"}),
+            b"frame",
+        ]
+    )
+    service = RoiService(skimmer=_FakeSkimmer(), beholder=beholder)
+
+    result = service.fetch_roi(
+        _FakeAssoc(), "https://example/video.mp4", elapsed_time_millis=123
+    )
+
+    assert result == "roi-slice"
+    assert len(beholder.calls) == 3
+    assert sleeps == [0.5, 0.5]
+
+
+def test_fetch_roi_gives_up_after_max_retries_on_persistent_beholder_503(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("vars_gridview.services.roi_service.time.sleep", lambda s: None)
+    beholder = _FakeBeholder(responses=[_httpx_status_error(503) for _ in range(10)])
+    service = RoiService(skimmer=_FakeSkimmer(), beholder=beholder)
+
+    result = service.fetch_roi(
+        _FakeAssoc(), "https://example/video.mp4", elapsed_time_millis=123
+    )
+
+    assert result is None
+    # Initial attempt plus the configured number of retries, no more.
+    assert len(beholder.calls) == 3
+
+
+def test_fetch_roi_does_not_retry_non_503_beholder_errors(monkeypatch) -> None:
+    monkeypatch.setattr("vars_gridview.services.roi_service.time.sleep", lambda s: None)
+    beholder = _FakeBeholder(responses=[_httpx_status_error(500)])
+    service = RoiService(skimmer=_FakeSkimmer(), beholder=beholder)
+
+    result = service.fetch_roi(
+        _FakeAssoc(), "https://example/video.mp4", elapsed_time_millis=123
+    )
+
+    assert result is None
+    assert len(beholder.calls) == 1

--- a/tests/test_roi_service.py
+++ b/tests/test_roi_service.py
@@ -12,22 +12,37 @@ class _FakeAssoc:
 
 
 class _FakeResponse:
-    def __init__(self, content: bytes = b"img") -> None:
+    def __init__(
+        self,
+        content: bytes = b"img",
+        status_code: int = 200,
+        headers: dict | None = None,
+    ) -> None:
         self.content = content
+        self.status_code = status_code
+        self.headers = headers or {}
 
     def raise_for_status(self) -> None:
-        return None
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} error")
 
 
 class _FakeSkimmer:
-    def __init__(self, *, raise_http_error: bool = False) -> None:
+    def __init__(
+        self, *, raise_http_error: bool = False, responses: list | None = None
+    ) -> None:
         self.raise_http_error = raise_http_error
         self.calls = []
+        # If given, one queued response is returned per call (in order),
+        # letting tests script a sequence like [503, 503, 200].
+        self._responses = list(responses) if responses is not None else None
 
     def crop(self, image_url, x, y, xf, yf):
         self.calls.append((image_url, x, y, xf, yf))
         if self.raise_http_error:
             raise requests.HTTPError("crop failed")
+        if self._responses is not None:
+            return self._responses.pop(0)
         return _FakeResponse(b"skimmer")
 
 
@@ -175,3 +190,67 @@ def test_fetch_full_image_returns_none_when_decode_fails(monkeypatch) -> None:
     result = service.fetch_full_image("https://example/image.jpg")
 
     assert result is None
+
+
+def test_fetch_roi_retries_skimmer_503_then_succeeds(monkeypatch) -> None:
+    sleeps = []
+    monkeypatch.setattr(
+        "vars_gridview.services.roi_service.time.sleep", lambda s: sleeps.append(s)
+    )
+    monkeypatch.setattr(
+        "vars_gridview.services.roi_service.np.frombuffer",
+        lambda *_args, **_kwargs: b"arr",
+    )
+    monkeypatch.setattr(
+        "vars_gridview.services.roi_service.cv2.imdecode",
+        lambda *_args, **_kwargs: "decoded",
+    )
+
+    skimmer = _FakeSkimmer(
+        responses=[
+            _FakeResponse(status_code=503, headers={"Retry-After": "0.5"}),
+            _FakeResponse(status_code=503, headers={"Retry-After": "0.5"}),
+            _FakeResponse(b"skimmer", status_code=200),
+        ]
+    )
+    service = RoiService(skimmer=skimmer, beholder=_FakeBeholder())
+
+    result = service.fetch_roi(_FakeAssoc(), "https://example/image.jpg")
+
+    assert result == "decoded"
+    assert len(skimmer.calls) == 3
+    assert sleeps == [0.5, 0.5]
+
+
+def test_fetch_roi_gives_up_after_max_retries_on_persistent_503(monkeypatch) -> None:
+    monkeypatch.setattr("vars_gridview.services.roi_service.time.sleep", lambda s: None)
+    skimmer = _FakeSkimmer(
+        responses=[_FakeResponse(status_code=503) for _ in range(10)]
+    )
+    service = RoiService(skimmer=skimmer, beholder=_FakeBeholder())
+
+    result = service.fetch_roi(_FakeAssoc(), "https://example/image.jpg")
+
+    assert result is None
+    # Initial attempt plus the configured number of retries, no more.
+    assert len(skimmer.calls) == 3
+
+
+def test_fetch_roi_retry_after_header_is_capped(monkeypatch) -> None:
+    sleeps = []
+    monkeypatch.setattr(
+        "vars_gridview.services.roi_service.time.sleep", lambda s: sleeps.append(s)
+    )
+    skimmer = _FakeSkimmer(
+        responses=[
+            _FakeResponse(status_code=503, headers={"Retry-After": "9999"}),
+            _FakeResponse(status_code=503, headers={"Retry-After": "not-a-number"}),
+            _FakeResponse(status_code=503),
+        ]
+    )
+    service = RoiService(skimmer=skimmer, beholder=_FakeBeholder())
+
+    service.fetch_roi(_FakeAssoc(), "https://example/image.jpg")
+
+    assert sleeps[0] == 5.0  # capped
+    assert sleeps[1] == 1.0  # unparsable -> default


### PR DESCRIPTION
- max_concurrency 4→16, skip debounce on bulk tile loads (was capping ~20-30 tiles/s regardless of backend speed)
- retry Skimmer/Beholder 503s with backoff instead of failing the tile